### PR TITLE
Update default maximum line limits and version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.1
+
+- **Default limits updated**:
+  - `class_length.max_lines`: 300 -> 500
+  - `file_length.max_lines`: 500 -> 700
+  - `function_length.max_lines`: 50 -> 75
+  - `function_length.build_method_max_lines`: 100 -> 150
+
 ## 1.3.0
 
 - **Cognitive complexity fix**: Nesting penalty now correctly accumulates `1 + currentNestingLevel` per nested construct (previously only added a flat `+1` bonus regardless of depth). Deeply nested code will now score higher and trigger warnings/errors more accurately.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ analyzer:
 custom_lint:
   rules:
     - class_length:
-        max_lines: 300                    # default: 300
+        max_lines: 500                    # default: 500
         stateful_widget_max_lines: 500    # default: 500
     - file_length:
-        max_lines: 500                    # default: 500
+        max_lines: 700                    # default: 700
     - function_length:
-        max_lines: 50                     # default: 50
-        build_method_max_lines: 100       # default: 100
+        max_lines: 75                     # default: 75
+        build_method_max_lines: 150       # default: 150
     - cognitive_complexity:
         medium_threshold: 10              # default: 10  (warning)
         high_threshold: 15               # default: 15  (error)

--- a/lib/src/best_practices/class_length_rule.dart
+++ b/lib/src/best_practices/class_length_rule.dart
@@ -5,7 +5,7 @@ import 'package:klin_dart/src/utils/ast_node_extensions.dart';
 
 class ClassLengthRule extends DartLintRule {
   /// The default maximum number of lines allowed in a class.
-  static const _defaultMaxLines = 300;
+  static const _defaultMaxLines = 500;
 
   static const _defaultStatefulWidgetMaxLines = 500;
 

--- a/lib/src/best_practices/file_length_rule.dart
+++ b/lib/src/best_practices/file_length_rule.dart
@@ -5,7 +5,7 @@ import 'package:analyzer/error/error.dart' as error;
 
 class FileLengthRule extends DartLintRule {
   /// The default maximum number of lines allowed in a file.
-  static const _defaultMaxLines = 500;
+  static const _defaultMaxLines = 700;
 
   /// The configurable maximum number of lines allowed.
   final int maxLines;

--- a/lib/src/best_practices/function_length_rule.dart
+++ b/lib/src/best_practices/function_length_rule.dart
@@ -7,8 +7,8 @@ import 'package:klin_dart/src/utils/ast_node_extensions.dart';
 
 class FunctionLengthRule extends DartLintRule {
   /// The default maximum number of lines allowed in a function.
-  static const _defaultMaxLines = 50;
-  static const _defaultBuildMethodMaxLines = 100;
+  static const _defaultMaxLines = 75;
+  static const _defaultBuildMethodMaxLines = 150;
 
   /// The configurable maximum number of lines allowed.
   final int maxLines;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: klin_dart
 description: KlinDart is a collection of opinionated custom lint rules for Dart and Flutter projects. It focuses on improving code readability, maintainability, and scalability by enforcing architectural and stylistic best practices.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/kevinchrist20/klin_dart
 
 environment:


### PR DESCRIPTION
This pull request updates the default limits for several lint rules related to code length, making them less restrictive and allowing for larger classes, files, and functions. The documentation and configuration examples have been updated accordingly.

**Default limit increases:**

* Increased the default maximum lines for classes from 300 to 500 in `class_length_rule.dart` and updated the corresponding example in `README.md`. [[1]](diffhunk://#diff-656fae2d03b4319b2b8f959f145b1f445e0cce7a726231bbc090458f9a8e7efbL8-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R61)
* Increased the default maximum lines for files from 500 to 700 in `file_length_rule.dart` and updated the corresponding example in `README.md`. [[1]](diffhunk://#diff-5a50d064b42fa426b4464993207985f5ed7a35fea847332ecf24578a6f6b4c68L8-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R61)
* Increased the default maximum lines for functions from 50 to 75 and for build methods from 100 to 150 in `function_length_rule.dart` and updated the corresponding example in `README.md`. [[1]](diffhunk://#diff-d1f4a52d4fd95c546e1864295a7ce8c564d83b60154e8ab5debc5ac46a52c85bL10-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R61)

**Documentation and metadata:**

* Updated the changelog to reflect the new default limits for class, file, and function lengths.
* Bumped the package version to `1.3.1` in `pubspec.yaml`.